### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/DS4P/pom.xml
+++ b/DS4P/pom.xml
@@ -200,7 +200,7 @@
 		<itextpdf.version>5.4.0</itextpdf.version>
 
 		<spring-amqp.version>1.1.4.RELEASE</spring-amqp.version>
-		<commons-collections.version>3.2.1</commons-collections.version>
+		<commons-collections.version>3.2.2</commons-collections.version>
 		<commons-beanutils-version>1.9.1</commons-beanutils-version>
 		<validation-api.version>1.0.0.GA</validation-api.version>
 		<cglib-nodep.version>2.2.2</cglib-nodep.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
